### PR TITLE
Blinking screens bug

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33,13 +33,28 @@ var app = (function(){
             }
 
             // Now switch to the starting page
-            sm.switchState(startingPage);
+            window.location.hash = startingPage;
 
-            // Attach an event handler to the page popping a state
-            $(window).on('popstate', function(jQueryEvent){
+            // If we're not already switching states from setting the hash above
+            if (!sm.isSwitching()) {
 
-                // Now switch to the state it should switch to
-                sm.switchState(jQueryEvent.originalEvent.state.storedState)
+                // And if we're not already in this state
+                if (sm.getCurrentState() !== window.location.hash.slice(1)) {
+
+                    // Switch to the starting page manually
+                    sm.switchState(startingPage);
+                }
+            }
+
+            // Attach an event handler to the window location hash change event
+            $(window).on('hashchange', function(jQueryEvent){
+
+                // If we're not already in this state
+                if (sm.getCurrentState() !== window.location.hash.slice(1)){
+
+                    // Switch to the state specified by the new window location hash
+                    sm.switchState(window.location.hash.slice(1)); // Slicing 1 here is grabbing the string minus the first character
+                }
             });
         },
     };

--- a/assets/js/imports/state-machine.js
+++ b/assets/js/imports/state-machine.js
@@ -10,6 +10,7 @@ var sm = (function(){
         // Set up the different variables needed to switch between States
         states: {},
         currentState: '',
+        currentlySwitching: false,
     };
 
     // Define our state machine public features here which will allow users to use it.
@@ -90,6 +91,9 @@ var sm = (function(){
 
             //#endregion
 
+            // Flag us as currently switching the state so we can prevent 'switchState' calls from happening inside switching states
+            privateFeatures.currentlySwitching = true;
+
             // Store the next state so individual states can plan accordingly
             var nextState = stateName;
 
@@ -112,6 +116,21 @@ var sm = (function(){
 
             // Load the new state
             privateFeatures.states[privateFeatures.currentState].loadState(previousState);
+
+            // Unflag us as currently switching the state
+            privateFeatures.currentlySwitching = false;
+        },
+
+        // Return whether the state machine is currently switching states or not
+        isSwitching: function () {
+
+            return privateFeatures.currentlySwitching;
+        },
+
+        // Return the current state name (which is a string)
+        getCurrentState: function () {
+
+            return privateFeatures.currentState;
         },
     };
 

--- a/assets/js/states/create-package-screen.js
+++ b/assets/js/states/create-package-screen.js
@@ -8,12 +8,12 @@ var createPackageScreenState = {
             console.log('done hiding create package screen');
             ui.get$FromRef('create-package-screen').css('position', 'static');
         });
+
+        // Detach button click events here too (this handles the case of using forward/back navigation buttons causing multiple fade ins/outs)
+        createPackageScreenState.clearButtonClickHandlers();
     },
 
     loadState: function (prevState) {
-
-        // Push this state to the browser history
-        history.pushState({storedState: 'create-package-screen'}, 'Create a Care Package', '#create-package-screen');
 
         // Show the create package screen
         ui.showByRef('create-package-screen', function(){
@@ -42,11 +42,10 @@ var createPackageScreenState = {
                 // END: Code to run immediately upon clicking the use button
 
                 // Detach the click event handlers from all the buttons
-                ui.get$FromRef('customize-buttons').off('click');
-                ui.get$FromRef('preview-button').off('click');
+                createPackageScreenState.clearButtonClickHandlers();
 
                 // Switch to the respective customization screen
-                sm.switchState('preview-screen');
+                window.location.hash = 'preview-screen';
             });
         });
     },
@@ -56,12 +55,17 @@ var createPackageScreenState = {
             console.log(`handling click on the ${$ref} customize button`);
 
             // Detach the click event handlers from all the buttons
-            ui.get$FromRef('customize-buttons').off('click');
-            ui.get$FromRef('preview-button').off('click');
+            createPackageScreenState.clearButtonClickHandlers();
 
             // Switch to the respective customization screen
-            sm.switchState(nextState);
+            window.location.hash = nextState;
         });
+    },
+
+    clearButtonClickHandlers: function () {
+
+        ui.get$FromRef('customize-buttons').off('click');
+        ui.get$FromRef('preview-button').off('click');
     },
 };
 

--- a/assets/js/states/customize-meme-screen.js
+++ b/assets/js/states/customize-meme-screen.js
@@ -9,6 +9,9 @@ var customizeMemeScreenState = {
             ui.get$FromRef('customize-meme-screen').css('position', 'static');
         });
 
+        // Detach button click events here too (this handles the case of using forward/back navigation buttons causing multiple fade ins/outs)
+        customizeMemeScreenState.clearButtonClickHandlers();
+
         // START: General code to run after this screen finishes transitioning out and immediately before the state switches
 
         //   >>> Replace this line with any code that may make sense here <<<
@@ -17,9 +20,6 @@ var customizeMemeScreenState = {
     },
     
     loadState: function (prevState) {
-
-        // Push this state to the browser history
-        history.pushState({storedState: 'customize-meme-screen'}, 'Customize your Meme', '#customize-meme-screen');
 
         // START: Code to run before this screen starts transitioning in
         // I'd suggest putting any changes here you want to be visible on the screen when it transitions in.
@@ -52,11 +52,10 @@ var customizeMemeScreenState = {
                 // END: Code to run immediately upon clicking the use button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-meme-button').off('click');
-                ui.get$FromRef('cancel-meme-button').off('click');
+                customizeMemeScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
 
             // Attach a click event handler to the cancel button (done here so its not clickable until fully on screen)
@@ -71,13 +70,18 @@ var customizeMemeScreenState = {
                 // END: Code to run immediately upon clicking the cancel button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-meme-button').off('click');
-                ui.get$FromRef('cancel-meme-button').off('click');
+                customizeMemeScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
         });
+    },
+
+    clearButtonClickHandlers: function () {
+
+        ui.get$FromRef('use-meme-button').off('click');
+        ui.get$FromRef('cancel-meme-button').off('click');
     },
 };
 

--- a/assets/js/states/customize-message-screen.js
+++ b/assets/js/states/customize-message-screen.js
@@ -9,6 +9,9 @@ var customizeMessageScreenState = {
             ui.get$FromRef('customize-message-screen').css('position', 'static');
         });
 
+        // Detach button click events here too (this handles the case of using forward/back navigation buttons causing multiple fade ins/outs)
+        customizeMessageScreenState.clearButtonClickHandlers();
+
         // START: General code to run after this screen finishes transitioning out and immediately before the state switches
 
         //   >>> Replace this line with any code that may make sense here <<<
@@ -17,9 +20,6 @@ var customizeMessageScreenState = {
     },
     
     loadState: function (prevState) {
-
-        // Push this state to the browser history
-        history.pushState({storedState: 'customize-message-screen'}, 'Customize your Message', '#customize-message-screen');
 
         // START: Code to run before this screen starts transitioning in
         // I'd suggest putting any changes here you want to be visible on the screen when it transitions in.
@@ -52,11 +52,10 @@ var customizeMessageScreenState = {
                 // END: Code to run immediately upon clicking the use button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-message-button').off('click');
-                ui.get$FromRef('cancel-message-button').off('click');
+                customizeMessageScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
 
             // Attach a click event handler to the cancel button (done here so its not clickable until fully on screen)
@@ -71,18 +70,24 @@ var customizeMessageScreenState = {
                 // END: Code to run immediately upon clicking the cancel button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-message-button').off('click');
-                ui.get$FromRef('cancel-message-button').off('click');
+                customizeMessageScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
         });
+    },
+
+    clearButtonClickHandlers: function () {
+
+        ui.get$FromRef('use-message-button').off('click');
+        ui.get$FromRef('cancel-message-button').off('click');
     },
 };
 
 // Add references to jQuery selections of HTML elements that are permanently on the page
 ui.add$ToRef('customize-message-screen', '#customize-message-screen');
+
 ui.add$ToRef('cancel-message-button', '.cancel-message-button');
 ui.add$ToRef('use-message-button', '.use-message-button');
 

--- a/assets/js/states/customize-postmates-screen.js
+++ b/assets/js/states/customize-postmates-screen.js
@@ -9,6 +9,9 @@ var customizePostmatesScreenState = {
             ui.get$FromRef('customize-postmates-screen').css('position', 'static');
         });
 
+        // Detach button click events here too (this handles the case of using forward/back navigation buttons causing multiple fade ins/outs)
+        customizePostmatesScreenState.clearButtonClickHandlers();
+
         // START: General code to run after this screen finishes transitioning out and immediately before the state switches
 
         //   >>> Replace this line with any code that may make sense here <<<
@@ -17,9 +20,6 @@ var customizePostmatesScreenState = {
     },
     
     loadState: function (prevState) {
-
-        // Push this state to the browser history
-        history.pushState({storedState: 'customize-postmates-screen'}, 'Customize your Postmates Delivery', '#customize-postmates-screen');
 
         // START: Code to run before this screen starts transitioning in
         // I'd suggest putting any changes here you want to be visible on the screen when it transitions in.
@@ -52,11 +52,10 @@ var customizePostmatesScreenState = {
                 // END: Code to run immediately upon clicking the use button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-postmates-button').off('click');
-                ui.get$FromRef('cancel-postmates-button').off('click');
+                customizePostmatesScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
 
             // Attach a click event handler to the cancel button (done here so its not clickable until fully on screen)
@@ -71,13 +70,18 @@ var customizePostmatesScreenState = {
                 // END: Code to run immediately upon clicking the cancel button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-postmates-button').off('click');
-                ui.get$FromRef('cancel-postmates-button').off('click');
+                customizePostmatesScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
         });
+    },
+
+    clearButtonClickHandlers: function () {
+
+        ui.get$FromRef('use-postmates-button').off('click');
+        ui.get$FromRef('cancel-postmates-button').off('click');
     },
 };
 

--- a/assets/js/states/customize-spotify-screen.js
+++ b/assets/js/states/customize-spotify-screen.js
@@ -12,6 +12,9 @@ var customizeSpotifyScreenState = {
             ui.get$FromRef('customize-spotify-screen').css('position', 'static');
         });
 
+        // Detach button click events here too (this handles the case of using forward/back navigation buttons causing multiple fade ins/outs)
+        customizeSpotifyScreenState.clearButtonClickHandlers();
+
         // START: General code to run after this screen finishes transitioning out and immediately before the state switches
 
         //   >>> Replace this line with any code that may make sense here <<<
@@ -20,9 +23,6 @@ var customizeSpotifyScreenState = {
     },
     
     loadState: function (prevState) {
-
-        // Push this state to the browser history
-        history.pushState({storedState: 'customize-spotify-screen'}, 'Customize your Spotify playlist', '#customize-spotify-screen');
 
         // START: Code to run before this screen starts transitioning in
         // I'd suggest putting any changes here you want to be visible on the screen when it transitions in.
@@ -82,17 +82,13 @@ var customizeSpotifyScreenState = {
                     customizeSpotifyScreenState.savedPlaylistID = customizeSpotifyScreenState.playlistID;
                 }
 
-                // Detach the click handlers from the playlist selection buttons
-                ui.get$FromRef('select-playlist-buttons').off('click');
-
                 // END: Code to run immediately upon clicking the use button
 
-                // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-spotify-button').off('click');
-                ui.get$FromRef('cancel-spotify-button').off('click');
+                // Detach all the button click event handlers
+                customizeSpotifyScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
 
             // Attach a click event handler to the cancel button (done here so its not clickable until fully on screen)
@@ -115,19 +111,25 @@ var customizeSpotifyScreenState = {
                     ui.get$FromRef('select-playlist-buttons').filter(`button[data-playlist-id="${customizeSpotifyScreenState.playlistID}"]`).attr('disabled', true);
                 }
 
-                // Detach the click handlers from the playlist selection buttons
-                ui.get$FromRef('select-playlist-buttons').off('click');
-
                 // END: Code to run immediately upon clicking the cancel button
 
-                // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-spotify-button').off('click');
-                ui.get$FromRef('cancel-spotify-button').off('click');
+                // Detach all the button click event handlers
+                customizeSpotifyScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
         });
+    },
+
+    clearButtonClickHandlers: function () {
+
+        // Detach the click handlers from the playlist selection buttons
+        ui.get$FromRef('select-playlist-buttons').off('click');
+
+        // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
+        ui.get$FromRef('use-spotify-button').off('click');
+        ui.get$FromRef('cancel-spotify-button').off('click');
     },
 };
 

--- a/assets/js/states/landing-screen.js
+++ b/assets/js/states/landing-screen.js
@@ -8,12 +8,12 @@ var landingScreenState = {
             console.log('done hiding landing screen');
             ui.get$FromRef('landing-screen').css('position', 'static');
         });
+
+        // Detach button click events here too (this handles the case of using forward/back navigation buttons causing multiple fade ins/outs)
+        landingScreenState.clearButtonClickHandlers();
     },
 
     loadState: function (prevState) {
-
-        // Push this state to the browser history
-        history.pushState({storedState: 'landing-screen'}, 'Send Care Meow', '#landing-screen');
 
         // Show the landing screen
         ui.showByRef('landing-screen', function(){
@@ -25,11 +25,16 @@ var landingScreenState = {
             console.log('handling click on the landing start button');
             
             // Detach the click event handler from the landing start button
-            ui.get$FromRef('landing-start-button').off('click');
+            landingScreenState.clearButtonClickHandlers();
 
-            // Now that we're done hiding the landing screen, switch to the about screen
-            sm.switchState('create-package-screen');
+            // Now that we're done hiding the landing screen, switch to the create package screen
+            window.location.hash = 'create-package-screen';
         });
+    },
+
+    clearButtonClickHandlers: function () {
+
+        ui.get$FromRef('landing-start-button').off('click');
     },
 };
 

--- a/assets/js/states/package-sent-screen.js
+++ b/assets/js/states/package-sent-screen.js
@@ -12,8 +12,6 @@ var packageSentScreenState = {
 
     loadState: function (prevState) {
 
-        history.pushState({storedState: 'package-sent-screen'}, 'Care Package Sent!', '#package-sent-screen');
-
         // Show the package sent screen
         ui.showByRef('package-sent-screen', function(){
             console.log('done showing package sent screen');

--- a/assets/js/states/preview-screen.js
+++ b/assets/js/states/preview-screen.js
@@ -9,6 +9,9 @@ var previewScreenState = {
             ui.get$FromRef('preview-screen').css('position', 'static');
         });
 
+        // Detach button click events here too (this handles the case of using forward/back navigation buttons causing multiple fade ins/outs)
+        previewScreenState.clearButtonClickHandlers();
+
         // START: General code to run after this screen finishes transitioning out and immediately before the state switches
 
         // Destroy the spotify player
@@ -18,8 +21,6 @@ var previewScreenState = {
     },
     
     loadState: function (prevState) {
-
-        window.history.pushState({storedState: 'preview-screen'}, 'Care Package Preview', '#preview-screen')
 
         // START: Code to run before this screen starts transitioning in
         // I'd suggest putting any changes here you want to be visible on the screen when it transitions in.
@@ -56,11 +57,10 @@ var previewScreenState = {
                 // END: Code to run immediately upon clicking the use button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-preview-button').off('click');
-                ui.get$FromRef('cancel-preview-button').off('click');
+                previewScreenState.clearButtonClickHandlers();
 
                 // Switch to the package sent screen
-                sm.switchState('package-sent-screen');
+                window.location.hash = 'package-sent-screen';
             });
 
             // Attach a click event handler to the cancel button (done here so its not clickable until fully on screen)
@@ -74,13 +74,18 @@ var previewScreenState = {
                 // END: Code to run immediately upon clicking the cancel button
 
                 // Detach the click event handlers from the main screen buttons (so they're not clicked more than once)
-                ui.get$FromRef('use-preview-button').off('click');
-                ui.get$FromRef('cancel-preview-button').off('click');
+                previewScreenState.clearButtonClickHandlers();
 
                 // Switch back to the create package screen
-                sm.switchState('create-package-screen');
+                window.location.hash = 'create-package-screen';
             });
         });
+    },
+
+    clearButtonClickHandlers: function () {
+
+        ui.get$FromRef('use-preview-button').off('click');
+        ui.get$FromRef('cancel-preview-button').off('click');
     },
 };
 


### PR DESCRIPTION
- Fixed the blinking issue by switching from using history's `popstate` event to location's `hashchange` event
- Added a couple methods to the state-machine.js file for usage to handle `index.html` redirecting to the `landing-screen`
- Also making sure to clear the button click events during unloading the state as well; so that unloading the state by history navigation still clears the event handlers.